### PR TITLE
Add shortcut for "Restart Kernel" and "Interrupt Kernel"

### DIFF
--- a/package.json
+++ b/package.json
@@ -121,6 +121,16 @@
                 "linux": "ctrl+alt+enter",
                 "when": "interactiveEditorHasProvider && interactiveEditorVisible && !interactiveEditorDocumentChanged || interactiveEditorHasProvider && interactiveEditorVisible && config.interactiveEditor.editMode != 'preview'",
                 "command": "interactiveEditor.applyEdits"
+            },
+            {
+                "key": "0 0",
+                "when": "notebookEditorFocused && !inputFocus",
+                "command": "jupyter.restartkernel"
+            },
+            {
+                "key": "i i",
+                "when": "notebookEditorFocused && !inputFocus",
+                "command": "jupyter.interruptkernel"
             }
         ]
     }


### PR DESCRIPTION
Added two keyboard shortcuts that match shortcuts used by JupyterLab
- `0 0` restarts the kernel
- `i i` interrupts the kernel

Fixes https://github.com/microsoft/vscode-jupyter-keymap/issues/9.