### PR TITLE
Adding shortcuts to move one cell up (U) and down (W)

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,6 +101,16 @@
                 "when": "notebookEditorFocused && !inputFocus && !notebookOutputFocused",
                 "command": "notebook.cell.toggleLineNumbers"
             },
+			{
+				"key": "U",
+				"when": "notebookEditorFocused && !inputFocus && !notebookOutputFocused",
+				"command": "notebook.cell.moveUp"
+			},
+			{
+				"key": "W",
+				"when": "notebookEditorFocused && !inputFocus && !notebookOutputFocused",
+				"command": "notebook.cell.moveDown"
+			},
             {
                 "key": "ctrl+shift+-",
                 "when": "editorTextFocus && inputFocus && notebookEditorFocused && !notebookOutputFocused",


### PR DESCRIPTION
There is two-keys shortcuts to move cells in VS Code.
However, one-key shortuts are more convenient.
I added U for move up and W for move down.