### PR TITLE
Add Mac Keybindings

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,6 +108,7 @@
             },
             {
                 "key": "ctrl+enter",
+                "mac": "cmd+enter",
                 "when": "!inlineChatVisible && notebookCellListFocused",
                 "command": "notebook.cell.executeAndFocusContainer"
             },
@@ -119,6 +120,7 @@
             {
                 "win": "ctrl+alt+enter",
                 "linux": "ctrl+alt+enter",
+                "mac": "cmd+alt+enter",
                 "when": "inlineChatHasProvider && inlineChatVisible && !inlineChatDocumentChanged || inlineChatHasProvider && inlineChatVisible && config.inlineChat.editMode != 'preview'",
                 "command": "interactive.acceptChanges"
             }

--- a/package.json
+++ b/package.json
@@ -120,7 +120,6 @@
             {
                 "win": "ctrl+alt+enter",
                 "linux": "ctrl+alt+enter",
-                "mac": "cmd+alt+enter",
                 "when": "inlineChatHasProvider && inlineChatVisible && !inlineChatDocumentChanged || inlineChatHasProvider && inlineChatVisible && config.inlineChat.editMode != 'preview'",
                 "command": "interactive.acceptChanges"
             }


### PR DESCRIPTION
On Mac, the Jupyter keybindings for execute cell is cmd+enter not ctrl+enter.

(Source: https://discourse.jupyter.org/t/most-useful-keyboard-shortcuts-for-notebook-lab/18113, https://www.dataschool.io/jupyter-notebook-keyboard-shortcuts/)

This PR adds that to package.json accordingly.

Related bug on VS Code: https://github.com/microsoft/vscode/issues/221892